### PR TITLE
Fix #2: don't default "collapseTo"

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,7 +35,7 @@ function PasteLinkify(options = {}) {
 
       transform = transform.wrapInline({type, data})
 
-      if (options.collapseTo || 'end') {
+      if (options.collapseTo) {
         transform = transform[`collapseTo${toPascal(options.collapseTo)}`]()
       }
 


### PR DESCRIPTION
This PR fixes #2, if `collapseTo` is not passed, it'll keep the selection intact (as mentioned in the README).
